### PR TITLE
Fix opening of image picker inside <Modal/>

### DIFF
--- a/UIImagePickerManager/UIImagePickerManager.m
+++ b/UIImagePickerManager/UIImagePickerManager.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     
     UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
     dispatch_async(dispatch_get_main_queue(), ^{
-        [root presentViewController:self.picker animated:YES completion:nil];
+        [root.presentedViewController presentViewController:self.picker animated:YES completion:nil];
     });
     
 }


### PR DESCRIPTION
This change fixes an error that occurs when trying to prevent the image picker from inside &lt;Modal/&gt;.

More on the issue here:
https://github.com/marcshilling/react-native-image-picker/issues/22

