### PR TITLE
Fix presentation on iPad

### DIFF
--- a/UIImagePickerManager/UIImagePickerManager.m
+++ b/UIImagePickerManager/UIImagePickerManager.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
 }
 
-- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
+- (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
     NSString *buttonTitle = [actionSheet buttonTitleAtIndex:buttonIndex];
 


### PR DESCRIPTION
While testing on the simulator this was not working. It looks like the iPad uses an alert view instead of action sheet. Changed from using clickedButtonAtIndex to didDismissWithButtonIndex. This fixed the problem.

Tests performed:
Not in modal on iPhone: pass
In modal on iPhone: pass
Not in modal on iPad: pass
In modal on iPad: FAILED (also failed before this change)

Also found this article: http://stackoverflow.com/questions/25510894/prevent-my-ios-8-ipad-actionsheet-from-dismissing-its-parent-viewcontroller
"Moving forward you should embrace UIAlertController."