### PR TITLE
Added support for action sheets without titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ var UIImagePickerManager = require('NativeModules').UIImagePickerManager;
 
   // Specify any or all of these keys
   var options = {
+    showTitle: true,
     title: 'Select Avatar',
     cancelButtonTitle: 'Cancel',
     takePhotoButtonTitle: 'Take Photo...',

--- a/UIImagePickerManager/UIImagePickerManager.m
+++ b/UIImagePickerManager/UIImagePickerManager.m
@@ -20,6 +20,7 @@ RCT_EXPORT_MODULE();
 {
     if (self = [super init]) {
         self.defaultOptions = @{
+            @"showTitle": @YES,
             @"title": @"Select a Photo",
             @"cancelButtonTitle": @"Cancel",
             @"takePhotoButtonTitle": @"Take Photo...",
@@ -43,7 +44,13 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         [self.options setValue:options[key] forKey:key];
     }
     
-    self.alertController = [UIAlertController alertControllerWithTitle:[self.options valueForKey:@"title"] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    if ([[self.options objectForKey:@"showTitle"] boolValue]) {
+        self.alertController = [UIAlertController alertControllerWithTitle:[self.options valueForKey:@"title"] message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    } else {
+      self.alertController = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    }
+    
+    
     
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:[self.options valueForKey:@"cancelButtonTitle"] style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         self.callback(@[@"cancel", [NSNull null]]); // Return callback for 'cancel' action (if is required)


### PR DESCRIPTION
Hi! 
Just a small PR to add support for having an action sheet without a title. At the moment I've added it simply as an option (```showTitle```): may be an idea to interpret  ```''``` or ```null``` as "don't display a title field" as well. 

![showtitle=false](https://github-cloud.s3.amazonaws.com/assets/1311302/10566288/2c0609be-75db-11e5-97dc-fe357b3f4f67.jpg)
*<b>Above:</b> ```title=''```*

![showtitle=true](https://github-cloud.s3.amazonaws.com/assets/1311302/10566276/cf7ef278-75da-11e5-8238-9fc197607658.jpg)
*<b>Above:</b> ```showTitle=false```*

