### PR TITLE
Add android options/response

### DIFF
--- a/Android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/Android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -37,6 +37,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
 
   private Uri mCameraCaptureURI;
   private Callback mCallback;
+  private Boolean noData = false;
 
   public ImagePickerModule(ReactApplicationContext reactContext, Activity mainActivity) {
     super(reactContext);
@@ -118,6 +119,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
   // NOTE: Currently not reentrant / doesn't support concurrent requests
   @ReactMethod
   public void launchCamera(ReadableMap options, Callback callback) {
+    if (options.hasKey("noData")) {
+        noData = options.getBoolean("noData");
+    }
+
     Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
     if (cameraIntent.resolveActivity(mMainActivity.getPackageManager()) == null) {
         callback.invoke(true, "error resolving activity");
@@ -146,6 +151,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
   // NOTE: Currently not reentrant / doesn't support concurrent requests
   @ReactMethod
   public void launchImageLibrary(ReadableMap options, Callback callback) {
+    if (options.hasKey("noData")) {
+        noData = options.getBoolean("noData");
+    }
+
     Intent libraryIntent = new Intent();
     libraryIntent.setType("image/");
     libraryIntent.setAction(Intent.ACTION_GET_CONTENT);
@@ -176,7 +185,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
 
     response.putString("path", uri.toString());
     response.putString("uri", realPath);
-    response.putString("data", getBase64StringFromFile(realPath));
+    if (!noData) {
+        response.putString("data", getBase64StringFromFile(realPath));
+    }
 
     mCallback.invoke(false, response);
   }

--- a/Android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/Android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -10,6 +10,8 @@ import android.util.Base64;
 import android.app.AlertDialog;
 import android.widget.ArrayAdapter;
 import android.content.DialogInterface;
+import android.graphics.BitmapFactory;
+import android.media.ExifInterface;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -189,6 +191,29 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
         response.putString("data", getBase64StringFromFile(realPath));
     }
 
+    BitmapFactory.Options options = new BitmapFactory.Options();
+    options.inJustDecodeBounds = true;
+    BitmapFactory.decodeFile(realPath, options);
+    response.putInt("width", options.outWidth);
+    response.putInt("height", options.outHeight);
+
+    try {
+        ExifInterface exif = new ExifInterface(realPath);
+        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+        boolean isVertical = true ;
+        switch (orientation) {
+            case ExifInterface.ORIENTATION_ROTATE_270:
+                isVertical = false ;
+                break;
+            case ExifInterface.ORIENTATION_ROTATE_90:
+                isVertical = false ;
+                break;
+        }
+        response.putBoolean("isVertical", isVertical);
+    } catch (IOException e) {
+        e.printStackTrace();
+    }
+    
     mCallback.invoke(false, response);
   }
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 # react-native-image-picker
 A React Native module that allows you to use the native UIImagePickerController UI to either select a photo from the device library or directly from the camera, like so:
 
-#### IOS
-![Screenshot of the UIActionSheet](https://github.com/marcshilling/react-native-image-picker/blob/master/AlertSheetImage.jpg)
+### IOS - Android
+<img title="IOS" src="https://github.com/marcshilling/react-native-image-picker/blob/master/AlertSheetImage.jpg" width="50%">
+<img title="Android" src="http://i.imgur.com/jMOLd6w.png" width="49%">
 
-#### Android
-![Screenshot of the UIActionSheet Android](http://i.imgur.com/jMOLd6w.png)
-
-**Requires iOS 8 or higher**
-
-**Requires Api 11 or higher**
+**Requires iOS 8 or higher for iOS - Requires Api 11 or higher for Android**
 
 ## Install
 
@@ -21,6 +17,8 @@ A React Native module that allows you to use the native UIImagePickerController 
 5. Compile and have fun
 
 ### Android
+1. `npm install react-native-image-picker@latest --save`
+
 ```gradle
 // file: android/settings.gradle
 ...
@@ -94,9 +92,6 @@ var UIImagePickerManager = require('NativeModules').UIImagePickerManager;
 
   When you want to display the picker:
   ```javascript
-
-  // Specify any or all of these keys
-  // title is actually the only field supported in android module
   var options = {
     title: 'Select Avatar', // specify null or empty string to remove the title
     cancelButtonTitle: 'Cancel',
@@ -116,13 +111,16 @@ var UIImagePickerManager = require('NativeModules').UIImagePickerManager;
     }
   };
 
-  // The first arg will be the options object for customization, the second is
-  // your callback which sends bool: didCancel, object: response.
-  //
-  // response.data is the base64 encoded image data
-  // response.uri is the uri to the local file asset on the device
-  // response.isVertical will be true if the image is vertically oriented
-  // response.width & response.height give you the image dimensions
+  /** 
+   * The first arg will be the options object for customization, the second is
+   * your callback which sends bool: didCancel, object: response.
+   *
+   * response.data is the base64 encoded image data
+   * response.uri is the uri to the local file asset on the device
+   * response.isVertical will be true if the image is vertically oriented
+   * response.width & response.height give you the image dimensions
+   */
+
   UIImagePickerManager.showImagePicker(options, (didCancel, response) => {
     console.log('Response = ', response);
 
@@ -165,3 +163,19 @@ var UIImagePickerManager = require('NativeModules').UIImagePickerManager;
     // Same code as in above section!
   });
   ```
+
+### Options
+
+option | iOS  | Android
+------ | ---- | -------
+title | OK | OK
+cancelButtonTitle | OK | OK
+takePhotoButtonTitle | OK | OK
+chooseFromLibraryButtonTitle | OK | OK
+customButtons | OK | -
+maxWidth | OK | -
+maxHeight | OK | -
+quality | OK | -
+allowsEditing | OK | -
+noData | OK | OK
+storageOptions | OK | -

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ dependencies {
 ```java
 // file: android/app/src/main/java/com/myappli/MainActivity.java
 ...
+import android.content.Intent; // import
 import com.imagepicker.ImagePickerPackage; // import
 
 public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/marcshilling/react-native-image-picker.git"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A React Native module that allows you to use the native UIImagePickerController UI to select a photo from the device library or directly from the camera.",
   "author": "Marc Shilling (marcshilling)",
   "contributors": [


### PR DESCRIPTION
Hello, me again !

### Android new options supported
- cancelButtonTitle
- takePhotoButtonTitle
- chooseFromLibraryButtonTitle
- noData

(same usage as iOS)

### Android response fields added
- isVertical
- width
- height

(same as iOS)

### Android improvement
- on BACK key press and on touch outside the dialog => the callback will be called with a didCancel true

### Readme
I add a table to the readme.md to show supported options for iOS and for Android, and also clarified Android and iOS part

### Publish
I also set the version to 0.9.1, it would be awesome to publish this version if you are willing to merge it !

NOTE : Just don't merge it right now, i'm currently working on maxWidth et maxHeight (just see that it was really usefull after pr ahah)