### PR TITLE
Add video support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # react-native-image-picker
 A React Native module that allows you to use the native UIImagePickerController UI to either select a photo from the device library or directly from the camera, like so:
 
-### IOS - Android
-<img title="IOS" src="https://github.com/marcshilling/react-native-image-picker/blob/master/AlertSheetImage.jpg" width="50%">
-<img title="Android" src="http://i.imgur.com/jMOLd6w.png" width="49%">
+### iOS
+** Requires iOS 8 or higher
 
-**Requires iOS 8 or higher for iOS - Requires Api 11 or higher for Android**
+<img title="IOS" src="https://github.com/marcshilling/react-native-image-picker/blob/master/AlertSheetImage.jpg" width="50%">
+
+### Android
+** Requires Api 11 or higher for Android
+
+<img title="Android" src="http://i.imgur.com/jMOLd6w.png" width="49%">
 
 ## Install
 
-### IOS
+### iOS
 1. `npm install react-native-image-picker@latest --save`
 2. In the XCode's "Project navigator", right click on your project's Libraries folder ➜ `Add Files to <...>`
 3. Go to `node_modules` ➜ `react-native-image-picker` ➜ select the `UIImagePickerManager` folder **Make sure you have 'Create Groups' selected**

--- a/UIImagePickerManager/UIImagePickerManager.m
+++ b/UIImagePickerManager/UIImagePickerManager.m
@@ -1,6 +1,8 @@
 #import "UIImagePickerManager.h"
 #import "RCTConvert.h"
 
+@import MobileCoreServices;
+
 @interface UIImagePickerManager ()
 
 @property (nonatomic, strong) UIAlertController *alertController;
@@ -141,6 +143,11 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         case RNImagePickerTargetCamera:
 #if TARGET_IPHONE_SIMULATOR
             NSLog(@"Camera not available on simulator");
+            self.callback(@[@NO, @{
+                @"error":@{
+                    @"reason": @"Camera not available on simulator"
+                }
+            }]);
             return;
 #else
             self.picker.sourceType = UIImagePickerControllerSourceTypeCamera;
@@ -156,6 +163,25 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
     if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
         self.picker.allowsEditing = true;
+    }
+    if ([[self.options objectForKey:@"mediaType"] isEqualToString:@"video"]) {
+        self.picker.mediaTypes = @[(NSString *)kUTTypeMovie];
+    } else {
+        self.picker.mediaTypes = @[(NSString *)kUTTypeImage];
+    }
+    if ([[self.options objectForKey:@"qualityType"] isEqualToString:@"high"]) {
+        self.picker.videoQuality = UIImagePickerControllerQualityTypeHigh;
+    } else if ([[self.options objectForKey:@"qualityType"] isEqualToString:@"low"]) {
+        self.picker.videoQuality = UIImagePickerControllerQualityTypeLow;
+    } else {
+        self.picker.videoQuality = UIImagePickerControllerQualityTypeMedium;
+    }
+    if (self.picker.sourceType == UIImagePickerControllerSourceTypeCamera &&
+        [[self.options objectForKey:@"cameraType"] isEqualToString:@"front"]) {
+        self.picker.cameraDevice = UIImagePickerControllerCameraDeviceFront;
+    } else if (self.picker.sourceType == UIImagePickerControllerSourceTypeCamera &&
+               [[self.options objectForKey:@"cameraType"] isEqualToString:@"back"]) {
+        self.picker.cameraDevice = UIImagePickerControllerCameraDeviceRear;
     }
     self.picker.modalPresentationStyle = UIModalPresentationCurrentContext;
     self.picker.delegate = self;
@@ -176,22 +202,36 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     dispatch_async(dispatch_get_main_queue(), ^{
         [picker dismissViewControllerAnimated:YES completion:nil];
     });
-
-    /* Picked Image */
+    
+    NSString* path;
+    NSString* fileName;
+    NSString *mediaType = [info objectForKey:UIImagePickerControllerMediaType];
+    
     UIImage *image;
-    if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
-      image = [info objectForKey:UIImagePickerControllerEditedImage];
+    if ([mediaType isEqualToString:(NSString *)kUTTypeImage]) {
+        /* Picked Image */
+        if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {
+            image = [info objectForKey:UIImagePickerControllerEditedImage];
+        }
+        else {
+            image = [info objectForKey:UIImagePickerControllerOriginalImage];
+        }
+        
+        /* creating a temp url to be passed */
+        NSString *tempFilename = [[NSUUID UUID] UUIDString];
+        if ([[[self.options objectForKey:@"imageFileType"] stringValue] isEqualToString:@"png"]) {
+            fileName = [tempFilename stringByAppendingString:@".png"];
+        }
+        else {
+            fileName = [tempFilename stringByAppendingString:@".jpg"];
+        }
+    } else if ([mediaType isEqualToString:(NSString *)kUTTypeMovie]) {
+        NSURL *videoURL = info[UIImagePickerControllerMediaURL];
+        fileName = videoURL.lastPathComponent;
     }
-    else {
-      image = [info objectForKey:UIImagePickerControllerOriginalImage];
-    }
-
-    /* creating a temp url to be passed */
-    NSString *ImageUUID = [[NSUUID UUID] UUIDString];
-    NSString *ImageName = [ImageUUID stringByAppendingString:@".jpg"];
-
+    
     // This will be the default URL
-    NSString* path = [[NSTemporaryDirectory()stringByStandardizingPath] stringByAppendingPathComponent:ImageName];
+    path = [[NSTemporaryDirectory()stringByStandardizingPath] stringByAppendingPathComponent:fileName];
     
     NSDictionary *storageOptions;
     // if storage options are provided change path to the documents directory
@@ -200,8 +240,8 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
         NSString *documentsDirectory = [paths objectAtIndex:0];
         // update path to save image to documents directory
-        path = [documentsDirectory stringByAppendingPathComponent:ImageName];
-
+        path = [documentsDirectory stringByAppendingPathComponent:fileName];
+        
         storageOptions = [self.options objectForKey:@"storageOptions"];
         // if extra path is provided try to create it
         if ([storageOptions objectForKey:@"path"]) {
@@ -212,54 +252,100 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             // if there was an error do not update path
             if (error != nil) {
                 NSLog(@"error creating directory: %@", error);
+                NSDictionary *errorResponse = @{
+                    @"error":@{
+                        @"reason": error.localizedFailureReason
+                    }
+                };
+                self.callback(@[@NO, errorResponse]);
+                return;
             }
             else {
-                path = [newPath stringByAppendingPathComponent:ImageName];
+                path = [newPath stringByAppendingPathComponent:fileName];
             }
         }
     }
     
-
-    
-    // Rotate the image for upload to web
-    image = [self fixOrientation:image];
-
-    //If needed, downscale image
-    float maxWidth = image.size.width;
-    float maxHeight = image.size.height;
-    if ([self.options valueForKey:@"maxWidth"]) {
-        maxWidth = [[self.options valueForKey:@"maxWidth"] floatValue];
-    }
-    if ([self.options valueForKey:@"maxHeight"]) {
-        maxHeight = [[self.options valueForKey:@"maxHeight"] floatValue];
-    }
-    image = [self downscaleImageIfNecessary:image maxWidth:maxWidth maxHeight:maxHeight];
-
     // Create the response object
     NSMutableDictionary *response = [[NSMutableDictionary alloc] init];
     
-    [response setObject:@(maxWidth) forKey:@"width"];
-    [response setObject:@(maxHeight) forKey:@"height"];
-
-    NSData *data = UIImageJPEGRepresentation(image, [[self.options valueForKey:@"quality"] floatValue]);
-    // base64 encoded image string, unless the caller doesn't want it
-    if (![[self.options objectForKey:@"noData"] boolValue]) {
-        NSString *dataString = [data base64EncodedStringWithOptions:0];
-        [response setObject:dataString forKey:@"data"];
+    float maxWidth;
+    float maxHeight;
+    if ([mediaType isEqualToString:(NSString *)kUTTypeImage]) {
+        // Rotate the image for upload to web
+        image = [self fixOrientation:image];
+        
+        //If needed, downscale image
+        maxWidth = image.size.width;
+        maxHeight = image.size.height;
+        if ([self.options valueForKey:@"maxWidth"]) {
+            maxWidth = [[self.options valueForKey:@"maxWidth"] floatValue];
+        }
+        if ([self.options valueForKey:@"maxHeight"]) {
+            maxHeight = [[self.options valueForKey:@"maxHeight"] floatValue];
+        }
+        image = [self downscaleImageIfNecessary:image maxWidth:maxWidth maxHeight:maxHeight];
+        
+        [response setObject:@(image.size.width) forKey:@"width"];
+        [response setObject:@(image.size.height) forKey:@"height"];
     }
-
-    // file uri
-    [data writeToFile:path atomically:YES];
+    else if ([mediaType isEqualToString:(NSString *)kUTTypeMovie]) {
+        // video resize code goes here
+    }
+    
+    NSData *data;
+    if ([mediaType isEqualToString:(NSString *)kUTTypeImage]) {
+        if ([[[self.options objectForKey:@"imageFileType"] stringValue] isEqualToString:@"png"]) {
+            data = UIImagePNGRepresentation(image);
+        } else {
+            data = UIImageJPEGRepresentation(image, [[self.options valueForKey:@"quality"] floatValue]);
+        }
+        // base64 encoded image string, unless the caller doesn't want it
+        if (![[self.options objectForKey:@"noData"] boolValue]) {
+            NSString *dataString = [data base64EncodedStringWithOptions:0];
+            [response setObject:dataString forKey:@"data"];
+        }
+        
+        // file uri
+        [data writeToFile:path atomically:YES];
+        
+        // image orientation
+        BOOL vertical = (image.size.width < image.size.height) ? YES : NO;
+        [response setObject:@(vertical) forKey:@"isVertical"];
+    }
+    else if ([mediaType isEqualToString:(NSString *)kUTTypeMovie]) {
+        NSURL *videoURL = info[UIImagePickerControllerMediaURL];
+        // generate the local video file URL
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSURL *localVideoURL = [NSURL fileURLWithPath:path];
+        
+        // delete the local video file if it already exists
+        if ([fileManager fileExistsAtPath:localVideoURL.path]) {
+            [fileManager removeItemAtURL:localVideoURL error:NULL];
+        }
+        // move the temp video file to the local video file path
+        NSError *error = nil;
+        [fileManager moveItemAtURL:videoURL toURL:localVideoURL error:&error];
+        path = localVideoURL.path;
+        
+        // invoke the callback if there was an error renaming the file
+        if (error) {
+            NSDictionary *errorResponse = @{
+                @"error":@{
+                    @"reason": error.localizedFailureReason
+                }
+            };
+            self.callback(@[@NO, errorResponse]);
+            return;
+        }
+    }
+    
     NSString *fileURL = [[NSURL fileURLWithPath:path] absoluteString];
     if ([[storageOptions objectForKey:@"skipBackup"] boolValue]) {
         [self addSkipBackupAttributeToItemAtPath:path];
     }
     [response setObject:fileURL forKey:@"uri"];
     
-    // image orientation
-    BOOL vertical = (image.size.width < image.size.height) ? YES : NO;
-    [response setObject:@(vertical) forKey:@"isVertical"];
-
     self.callback(@[@NO, response]);
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/marcshilling/react-native-image-picker.git"
   },
-  "version": "0.9.1",
+  "version": "0.10.1",
   "description": "A React Native module that allows you to use the native UIImagePickerController UI to select a photo from the device library or directly from the camera.",
   "author": "Marc Shilling (marcshilling)",
   "contributors": [


### PR DESCRIPTION
Initial support for recording video or picking videos from the image picker. The code now looks for 'mediaType' to determine if it should take a 'photo' or a 'video'.

Added code to use the option key 'qualityType' to set 'high', 'medium' and 'low' image quality settings. Defaults to 'medium'.

Added code to check the option key 'imageFileType'. imageFileType === 'png' exports the photo as PNG instead of JPG. Defaults to JPG if imageFileType is not set or if set to any value other than 'png'.

Added some error reporting when some steps fail, rather than just writing to the console and either ignoring the error or returning early.

Updated the version number in package.json