### PR TITLE
Handle case where we can't extract the image path in Android

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -270,6 +270,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
             && quality == 100) {
         response.putInt("width", initialWidth);
         response.putInt("height", initialHeight);
+    } else if (realPath == null) {
+      response.putString("error", "could not resize image");
+      mCallback.invoke(response);
+      return;
     } else {
         uri = getResizedImage(getRealPathFromURI(uri), initialWidth, initialHeight);
         realPath = getRealPathFromURI(uri);

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -236,24 +236,26 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
         return;
     }
 
-    try {
-        ExifInterface exif = new ExifInterface(realPath);
-        int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
-        boolean isVertical = true ;
-        switch (orientation) {
-            case ExifInterface.ORIENTATION_ROTATE_270:
-                isVertical = false ;
-                break;
-            case ExifInterface.ORIENTATION_ROTATE_90:
-                isVertical = false ;
-                break;
-        }
-        response.putBoolean("isVertical", isVertical);
-    } catch (IOException e) {
-        e.printStackTrace();
-        response.putString("error", e.getMessage());
-        mCallback.invoke(response);
-        return;
+    if (realPath != null) {
+      try {
+          ExifInterface exif = new ExifInterface(realPath);
+          int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+          boolean isVertical = true ;
+          switch (orientation) {
+              case ExifInterface.ORIENTATION_ROTATE_270:
+                  isVertical = false ;
+                  break;
+              case ExifInterface.ORIENTATION_ROTATE_90:
+                  isVertical = false ;
+                  break;
+          }
+          response.putBoolean("isVertical", isVertical);
+      } catch (IOException e) {
+          e.printStackTrace();
+          response.putString("error", e.getMessage());
+          mCallback.invoke(response);
+          return;
+      }
     }
 
     BitmapFactory.Options options = new BitmapFactory.Options();


### PR DESCRIPTION
The method `getRealPathFromURI` doesn't always work with Android 4.4 and newer – try using Google Photos, for instance, and you'll see it's unable to get the path, returning a `null`. As a result all calls relying on this path are throwing an exception and causing the app to crash.

I'm really no experienced Android developer, but it seems like part of the problem is that [we can't assume the URI returned by the intent always maps to a file](http://stackoverflow.com/a/20402190/16882). For this reason I'm proposing here that we don't try to fetch image details when we don't have a local file, which suits my purposes.

The best approach would obviously be to find a way to extract a path for images coming from 4.4+ and Google Photos. They have the URI like `content://com.google.android.apps.photos.contentprovider`. [Some developers say it's possible](http://stackoverflow.com/a/20559175/16882), but after putting a few hours porting that solution (and [aFileChooser's implementation itself](https://github.com/iPaulPro/aFileChooser/blob/48d65e6649d4201407702b0390326ec9d5c9d17c/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java#L257)) to this package I just wasn't able to get it to work – still getting `null` path.