### PR TITLE
Handle case where we can't extract the image path in Android (v2)

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -277,6 +277,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
     }
 
     response.putString("uri", uri.toString());
+    response.putString("urlPath", realPath);
 
     if (!noData) {
         response.putString("data", getBase64StringFromFile(realPath));

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -229,6 +229,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
       }
       catch(Exception e) {
         response.putString("error", "Could not read photo");
+        response.putString("uri", uri.toString());
         mCallback.invoke(response);
         return;
       }

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -234,21 +234,6 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
       }
     }
 
-    boolean isUrl = true;
-    try {
-        URL url = new URL(realPath);
-    }
-    catch (MalformedURLException e) {
-        isUrl = false;
-    }
-    if (isUrl) {
-        // @todo handle url as well (Facebook image, etc..)
-        response.putString("uri", uri.toString());
-        response.putString("urlPath", realPath);
-        mCallback.invoke(response);
-        return;
-    }
-
     try {
         ExifInterface exif = new ExifInterface(realPath);
         int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -287,7 +287,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
     }
 
     response.putString("uri", uri.toString());
-    response.putString("urlPath", realPath);
+    response.putString("path", realPath);
 
     if (!noData) {
         response.putString("data", getBase64StringFromFile(realPath));

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -221,7 +221,18 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
     : data.getData();
 
     String realPath = getRealPathFromURI(uri);
-    if (realPath ==  null) {
+    boolean isUrl = false;
+
+    if (realPath != null) {
+      try {
+        URL url = new URL(realPath);
+        isUrl = true;
+      } catch (MalformedURLException e) {
+        // not a url
+      }
+    }
+
+    if (realPath ==  null || isUrl) {
       try {
         File file = createFileFromURI(uri);
         realPath = file.getAbsolutePath();


### PR DESCRIPTION
Previous discussion: https://github.com/marcshilling/react-native-image-picker/pull/88

Here instead of just rejecting images without a path we actually create a new temporary file and copy from whatever URI was returned to the image intent. Tested this handles the `content://` URI in 4.4+.