### PR TITLE
Tweak activity not found handler

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -204,6 +204,13 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
 
     Intent libraryIntent = new Intent(Intent.ACTION_PICK,
         android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+
+    if (libraryIntent.resolveActivity(mMainActivity.getPackageManager()) == null) {
+        response.putString("error", "Cannot launch photo library");
+        callback.invoke(response);
+        return;
+    }
+
     mCallback = callback;
 
     try {

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -180,8 +180,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
         mMainActivity.startActivityForResult(cameraIntent, REQUEST_LAUNCH_CAMERA);
     }
     catch(ActivityNotFoundException e) {
-        response.putString("error", "Camera not available");
-        callback.invoke(response);
+        e.printStackTrace();
     }
   }
 
@@ -211,8 +210,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
         mMainActivity.startActivityForResult(libraryIntent, REQUEST_LAUNCH_IMAGE_LIBRARY);
     }
     catch(ActivityNotFoundException e) {
-        response.putString("error", "Photo library not available");
-        callback.invoke(response);
+        e.printStackTrace();
     }
   }
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -153,7 +153,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
 
     Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
     if (cameraIntent.resolveActivity(mMainActivity.getPackageManager()) == null) {
-        response.putString("error", "error resolving activity");
+        response.putString("error", "Cannot launch camera");
         callback.invoke(response);
         return;
     }


### PR DESCRIPTION
Further testing #91 on 4.1 I ran into this exception:

```
E/AndroidRuntime( 4176): FATAL EXCEPTION: mqt_native_modules
E/AndroidRuntime( 4176): com.facebook.react.bridge.ObjectAlreadyConsumedException: Receiving map already consumed
E/AndroidRuntime( 4176): 	at com.facebook.react.bridge.WritableNativeMap.putString(Native Method)
E/AndroidRuntime( 4176): 	at com.imagepicker.ImagePickerModule.launchImageLibrary(ImagePickerModule.java:216)
E/AndroidRuntime( 4176): 	at com.imagepicker.ImagePickerModule$1.onClick(ImagePickerModule.java:114)
```

I think the issue is that the callback is triggering even though the activity doesn't exist (prob on a different thread?). I confirmed this is the case because `onActivityResult` was being called with result cancel, so RN received the callback with `didCancel` set – and then freaked out when we tried to send the error message on that same callback.

To solve I changed the original `ActivityNotFoundException` error handlers to just print the exception, and then added a explicit test to see if the `libraryIntent` can run (similar to what was already in there for the camera). As a result I'm now getting a error on 4.1 as expected, phew.

Sorry for the trouble, let me know if there's anything I can help test/clarify here.