### PR TITLE
Fix iOS7 crash

### DIFF
--- a/ios/UIImagePickerManager.m
+++ b/ios/UIImagePickerManager.m
@@ -248,7 +248,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     NSString *fileName;
     if ([mediaType isEqualToString:(NSString *)kUTTypeImage]) {
         NSString *tempFileName = [[NSUUID UUID] UUIDString];
-        if ([[imageURL absoluteString] containsString:@"ext=GIF"]) {
+        if ([[imageURL absoluteString] rangeOfString:@"ext=GIF"].location != NSNotFound) {
             fileName = [tempFileName stringByAppendingString:@".gif"];
         }
         else if ([[[self.options objectForKey:@"imageFileType"] stringValue] isEqualToString:@"png"]) {
@@ -303,7 +303,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }
         
         // GIFs break when resized, so we handle them differently
-        if ([[imageURL absoluteString] containsString:@"ext=GIF"]) {
+        if ([[imageURL absoluteString] rangeOfString:@"ext=GIF"].location != NSNotFound) {
             ALAssetsLibrary* assetsLibrary = [[ALAssetsLibrary alloc] init];
             [assetsLibrary assetForURL:imageURL resultBlock:^(ALAsset *asset) {
                 ALAssetRepresentation *rep = [asset defaultRepresentation];


### PR DESCRIPTION
containsString is an iOS8+ method and as such crashes on iOS7. Using
rangeOfString fixes that.