### PR TITLE
Android: Add null checks for options

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -84,12 +84,14 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
       String cancelButtonTitle = "Cancel";
 
       if (options.hasKey("takePhotoButtonTitle")
-              && !options.getString("takePhotoButtonTitle").isEmpty()) {
+              && options.getString("takePhotoButtonTitle") != null
+	          && !options.getString("takePhotoButtonTitle").isEmpty()) {
           mTitles.add(options.getString("takePhotoButtonTitle"));
           mActions.add("photo");
       }
       if (options.hasKey("chooseFromLibraryButtonTitle")
-              && !options.getString("chooseFromLibraryButtonTitle").isEmpty()) {
+              && options.getString("chooseFromLibraryButtonTitle") != null
+	          && !options.getString("chooseFromLibraryButtonTitle").isEmpty()) {
           mTitles.add(options.getString("chooseFromLibraryButtonTitle"));
           mActions.add("library");
       }


### PR DESCRIPTION
According to the readme for options `takePhotoButtonTitle` and `chooseFromLibraryButtonTitle` you can "specify null or empty string to remove this button"

This PR allows these options to be set to null. Tested with RN 0.19.0.