### PR TITLE
reorient image on image resize

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -501,6 +501,23 @@ public class ImagePickerModule extends ReactContextBaseJavaModule implements Act
     matrix.postRotate(angle);
     matrix.postScale((float) ratio, (float) ratio);
 
+    ExifInterface exif;
+    try {
+      exif = new ExifInterface(realPath);
+
+      int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0);
+
+      if (orientation == 6) {
+        matrix.postRotate(90);
+      } else if (orientation == 3) {
+        matrix.postRotate(180);
+      } else if (orientation == 8) {
+        matrix.postRotate(270);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
     scaledphoto = Bitmap.createBitmap(photo, 0, 0, photo.getWidth(), photo.getHeight(), matrix, true);
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     scaledphoto.compress(Bitmap.CompressFormat.JPEG, quality, bytes);


### PR DESCRIPTION
When images are too large on our nicer Android devices, our image orientation is incorrect. From what I learned from [this article](http://voidcanvas.com/whatsapp-like-image-compression-in-android/), the correct orientation is restored, and the `angle` option is still regarded. 

I tested on both a phone that had this issue and one that didn't. 

Hopefully the code is sound - I don't code in Java, really. 