### PR TITLE
Add duration limit option to iOS

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -225,6 +225,12 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         else {
             self.picker.videoQuality = UIImagePickerControllerQualityTypeMedium;
         }
+
+        id durationLimit = [self.options objectForKey:@"durationLimit"];
+        if (durationLimit) {
+            self.picker.videoMaximumDuration = [durationLimit doubleValue];
+        }
+
     }
     else {
         self.picker.mediaTypes = @[(NSString *)kUTTypeImage];


### PR DESCRIPTION
Hello,

Here is a very simple implementation of the `durationLimit` option for iOS using [`picker.videoMaximumDuration`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIImagePickerController_Class/#//apple_ref/occ/instp/UIImagePickerController/videoMaximumDuration)

This would probably close #115.