### PR TITLE
Add ref to asset library version for color grabber

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -387,6 +387,9 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
             NSURL *fileURL = [NSURL fileURLWithPath:path];
             NSString *filePath = [fileURL absoluteString];
             [response setObject:filePath forKey:@"uri"];
+            // add ref to asset library version for color grabber
+            NSString *origURL = [imageURL absoluteString];
+            [response setObject:origURL forKey:@"origURI"];
 
             NSNumber *fileSizeValue = nil;
             NSError *fileSizeError = nil;


### PR DESCRIPTION
Add origURL to the returned object. This is a reference to the asset library handle of the original image. It can be passed to [react-native-color-grabber](https://github.com/bsudekum/react-native-color-grabber)