### PR TITLE
Show all media types

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -233,7 +233,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
     }
     else {
-        self.picker.mediaTypes = @[(NSString *)kUTTypeImage];
+        self.picker.mediaTypes = @[(NSString*)kUTTypeImage, (NSString*)kUTTypeVideo, (NSString*)kUTTypeMovie];
     }
 
     if ([[self.options objectForKey:@"allowsEditing"] boolValue]) {


### PR DESCRIPTION
When the media types are not specified while calling the API, show all of them.