### PR TITLE
Adds "mixed" option to "mediaType" for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ takePhotoButtonTitle | OK | OK | Specify `null` or empty string to remove this b
 chooseFromLibraryButtonTitle | OK | OK | Specify `null` or empty string to remove this button
 customButtons | OK | OK | An object in the form of `[Button Text] : [String returned upon selection]`
 cameraType | OK | - | 'front' or 'back'
-mediaType | OK | OK | 'video' or 'photo'
+mediaType | OK | OK | 'video' or 'photo'; (*'mixed' on iOS only*)
 maxWidth | OK | OK | Photos only
 maxHeight | OK | OK | Photos only
 quality | OK | OK | 0 to 1, photos only


### PR DESCRIPTION
This PR provides the "mixed" option as suggested by @marcshilling in #200.

As a result, when the image picker `mediaType` is set to 
- *video*: You see only videos, and video props (like `durationLimit`) are set.
- *image*: You see only images.
- *mixed*: You see both, and video props are set.

The default behavior is, as before, to show only images.

Additionally, this PR fixes a counterintuitive feature of the `durationLimit` prop, as noted in the commit message: Previously, if "durationLimit" was set but "allowsEditing" was false, then the durationLimit would not be applied, which was counterintuitive.  Now setting the "durationLimit" automatically sets "allowsEditing" to true, so that the user can select a segment of the video if it's under the `videoMaximumDuration` property.  I think this is more intuitive than the previous behavior, especially for developers coming to RN from the web, who won't know the underlying implementation of `UIImagePickerController`. (After all, I really can't think of a use case where you would set `durationLimit` without `allowsEditing`, therefore having the sure and certain knowledge that `durationLimit` won't even be applied).

(Btw, I have my editor set to remove trailing white space on save, and didn't realize until I committed this change.  Sorry for the additional "changed" lines in `ImagePickerManager.m`)