### PR TITLE
Save to camera roll option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ noData | OK | OK | If true, disables the base64 `data` field from being generate
 storageOptions | OK | OK | If this key is provided, the image will get saved in the Documents directory on iOS, and the Pictures directory on Android (rather than a temporary directory)
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save image at /Documents/[path] rather than the root
+storageOptions.cameraRoll | OK | - | If true, the cropped photo will be saved to the iOS Camera roll.
 
 ### The Response Object
 

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -409,6 +409,11 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
             [response setObject:@(image.size.width) forKey:@"width"];
             [response setObject:@(image.size.height) forKey:@"height"];
+
+            NSDictionary *storageOptions = [self.options objectForKey:@"storageOptions"];
+            if (storageOptions && [[storageOptions objectForKey:@"cameraRoll"] boolValue] == YES) {
+              UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil);
+            }
         }
         else { // VIDEO
             NSURL *videoURL = info[UIImagePickerControllerMediaURL];


### PR DESCRIPTION
This adds an option under `storageOptions` called `cameraRoll` which, if set to `true`, will save the resulting cropped image to the iOS Camera Roll.