### PR TITLE
Fix empty initialWidth and initialHeight [Android]

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -413,6 +413,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
 
     BitmapFactory.Options options = new BitmapFactory.Options();
     options.inJustDecodeBounds = true;
+    BitmapFactory.decodeFile(realPath, options);
     int initialWidth = options.outWidth;
     int initialHeight = options.outHeight;
 


### PR DESCRIPTION
I'm getting a consistent crash on Android when using the camera to take a photo:

```
09-15 18:12:13.126  3323  3323 E AndroidRuntime: Caused by: java.lang.IllegalArgumentException: width and height must be > 0
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at android.graphics.Bitmap.createBitmap(Bitmap.java:877)
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at android.graphics.Bitmap.createBitmap(Bitmap.java:856)
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at android.graphics.Bitmap.createBitmap(Bitmap.java:787)
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at com.imagepicker.ImagePickerModule.getResizedImage(ImagePickerModule.java:625)
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at com.imagepicker.ImagePickerModule.onActivityResult(ImagePickerModule.java:425)
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at com.imagepicker.ImagePickerModule$1.callback(ImagePickerModule.java:90)
09-15 18:12:13.126  3323  3323 E AndroidRuntime: 	at com.imagepicker.ImagePickerActivityEventListener.onActivityResult(ImagePickerActivityEventListener.java:26)
```

Seems like `initialWidth` and `initialHeight` are zero and it ends up causing the ratio in `getResizedImage` to be `NaN`. Simply putting the decode that was removed a few commits ago back in correctly sets the width and height and fixes the crash for me. Might also help for #312, but I haven't checked.