### PR TITLE
Send originalRotation in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,4 +209,4 @@ path | - | OK | The file path
 latitude | - | OK | Latitude metadata, if available
 longitude | - | OK | Longitude metadata, if available
 timestamp | - | OK | Timestamp metadata, if available, in ISO8601 UTC format
-originalRotation | OK | OK | Rotation degrees (photos only) *See [#109](/../../issues/199)*
+originalRotation | - | OK | Rotation degrees (photos only) *See [#109](/../../issues/199)*

--- a/README.md
+++ b/README.md
@@ -209,3 +209,4 @@ path | - | OK | The file path
 latitude | - | OK | Latitude metadata, if available
 longitude | - | OK | Longitude metadata, if available
 timestamp | - | OK | Timestamp metadata, if available, in ISO8601 UTC format
+originalRotation | OK | OK | Rotation degrees (photos only) *See [#109](/../../issues/199)*

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -410,6 +410,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
           currentRotation = 180;
           break;
       }
+      response.putInt("originalRotation", currentRotation);
       response.putBoolean("isVertical", isVertical);
     } catch (IOException e) {
       e.printStackTrace();

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -371,6 +371,7 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
             [self.response setObject:@(image.size.width) forKey:@"width"];
             [self.response setObject:@(image.size.height) forKey:@"height"];
+            [self.response setObject:@([self getOriginalRotationDegrees:image].integerValue) forKey:@"originalRotation"];
 
             NSDictionary *storageOptions = [self.options objectForKey:@"storageOptions"];
             if (storageOptions && [[storageOptions objectForKey:@"cameraRoll"] boolValue] == YES && self.picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
@@ -539,6 +540,27 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     UIGraphicsEndImageContext();
 
     return newImage;
+}
+
+- (NSNumber *)getOriginalRotationDegrees:(UIImage *)srcImg {
+    NSNumber *result = [NSNumber numberWithInteger:0];
+    
+    switch (srcImg.imageOrientation) {
+        case UIImageOrientationLeft:
+        case UIImageOrientationLeftMirrored:
+            result = [NSNumber numberWithInteger:90];
+            break;
+        case UIImageOrientationDown:
+        case UIImageOrientationDownMirrored:
+            result = [NSNumber numberWithInteger:180];
+            break;
+        case UIImageOrientationRight:
+        case UIImageOrientationRightMirrored:
+            result = [NSNumber numberWithInteger:270];
+            break;
+    }
+    
+    return result;
 }
 
 - (UIImage *)fixOrientation:(UIImage *)srcImg {

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -371,7 +371,6 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
 
             [self.response setObject:@(image.size.width) forKey:@"width"];
             [self.response setObject:@(image.size.height) forKey:@"height"];
-            [self.response setObject:@([self getOriginalRotationDegrees:image].integerValue) forKey:@"originalRotation"];
 
             NSDictionary *storageOptions = [self.options objectForKey:@"storageOptions"];
             if (storageOptions && [[storageOptions objectForKey:@"cameraRoll"] boolValue] == YES && self.picker.sourceType == UIImagePickerControllerSourceTypeCamera) {
@@ -540,27 +539,6 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
     UIGraphicsEndImageContext();
 
     return newImage;
-}
-
-- (NSNumber *)getOriginalRotationDegrees:(UIImage *)srcImg {
-    NSNumber *result = [NSNumber numberWithInteger:0];
-    
-    switch (srcImg.imageOrientation) {
-        case UIImageOrientationLeft:
-        case UIImageOrientationLeftMirrored:
-            result = [NSNumber numberWithInteger:90];
-            break;
-        case UIImageOrientationDown:
-        case UIImageOrientationDownMirrored:
-            result = [NSNumber numberWithInteger:180];
-            break;
-        case UIImageOrientationRight:
-        case UIImageOrientationRightMirrored:
-            result = [NSNumber numberWithInteger:270];
-            break;
-    }
-    
-    return result;
 }
 
 - (UIImage *)fixOrientation:(UIImage *)srcImg {


### PR DESCRIPTION
Hey @marcshilling, awesome library!

This PR addresses #199 (issue was closed but not fixed).

For some devices (notably Samsung Galaxy S3, S5) and image will have a rotate value (90 deg) in the Exif data even if the image was never rotated.

So if you try to upload the image somewhere and then later grab it and render it, the image is rendered in the wrong orientation compared to the original.

I'm not sure if this needs to be handled at the library level but this PR simply at least passes that value as part of the response so if an image has a rotate value attached to it the client can decide how to handle (like transform the image 90deg to account for it)

Note: this hasn't been an issue for iOS but I figured I'd add it, I can remove it if that's easier