### PR TITLE
make the resized image not being stretched

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -598,10 +598,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule {
     }
 
     Bitmap scaledphoto = null;
-    if (maxWidth == 0) {
+    if (maxWidth == 0 || maxWidth > initialWidth) {
       maxWidth = initialWidth;
     }
-    if (maxHeight == 0) {
+    if (maxHeight == 0 || maxWidth > initialHeight) {
       maxHeight = initialHeight;
     }
     double widthRatio = (double) maxWidth / initialWidth;


### PR DESCRIPTION
if maxWidth and maxHeight in options were large than initial size, will use the initial size.