### PR TITLE
Update ImagePickerActivityEventListener to use newer React Native API.

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerActivityEventListener.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerActivityEventListener.java
@@ -3,11 +3,11 @@ package com.imagepicker;
 import android.app.Activity;
 import android.content.Intent;
 
-import com.facebook.react.bridge.BaseActivityEventListener;
+import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
 
 
-public class ImagePickerActivityEventListener extends BaseActivityEventListener {
+public class ImagePickerActivityEventListener implements ActivityEventListener {
 
     private ActivityResultInterface mCallback;
 


### PR DESCRIPTION
Hi, there!

This pull request fixes an issue I faced using React Native 0.39 on Android:

```
/Users/kanerogers/Development/traxi/traxi/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerActivityEventListener.java:6: error: cannot find symbol
import com.facebook.react.bridge.BaseActivityEventListener;
                                ^
  symbol:   class BaseActivityEventListener
  location: package com.facebook.react.bridge
/Users/kanerogers/Development/traxi/traxi/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerActivityEventListener.java:10: error: cannot find symbol
public class ImagePickerActivityEventListener extends BaseActivityEventListener {
                                                      ^
  symbol: class BaseActivityEventListener
/Users/kanerogers/Development/traxi/traxi/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerActivityEventListener.java:15: error: incompatible types: ImagePickerActivityEventListener cannot be converted to ActivityEventListener
        reactContext.addActivityEventListener(this);
```

Thanks again for a fantastic library! ❤️ 