### PR TITLE
added null check for buttons title in options

### DIFF
--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -117,10 +117,13 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         }
     }
 
-    if ([action.title isEqualToString:[self.options valueForKey:@"takePhotoButtonTitle"]]) { // Take photo
+    NSString *takePhotoButtonTitle = [self.options valueForKey:@"takePhotoButtonTitle"];
+    NSString *chooseFromLibraryButtonTitle = [self.options valueForKey:@"chooseFromLibraryButtonTitle"];
+
+    if (![takePhotoButtonTitle isEqual:[NSNull null]] && [action.title isEqualToString:takePhotoButtonTitle]) { // Take photo
         [self launchImagePicker:RNImagePickerTargetCamera];
     }
-    else if ([action.title isEqualToString:[self.options valueForKey:@"chooseFromLibraryButtonTitle"]]) { // Choose from library
+    else if (![chooseFromLibraryButtonTitle isEqual:[NSNull null]] && [action.title isEqualToString:chooseFromLibraryButtonTitle]) { // Choose from library
         [self launchImagePicker:RNImagePickerTargetLibrarySingleImage];
     }
 }


### PR DESCRIPTION
Hi!

Thanks for your great library!

We found one strange bug which occur if 
`takePhotoButtonTitle == null` and 
`chooseFromLibraryButtonTitle` is less than 10 symbols plus is assigned dynamically (from texts system)

The reason is difference in serialization of strings with different length.
In details explained here:
http://stackoverflow.com/questions/33105750/nsjsonserialization-generating-nscfstring-and-nstaggedpointerstring

To solve this we added explicit check that `takePhotoButtonTitle` and `chooseFromLibraryButtonTitle` are not null