### PR TITLE
fix(android): add option to wait for image/video to be stored before the callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ xcuserdata/
 node_modules
 *.log
 
-## Android iml
+## Android Studio
 *.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ storageOptions | OK | OK | If this key is provided, the image will get saved in 
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save image at /Documents/[path] rather than the root
 storageOptions.cameraRoll | OK | - | If true, the cropped photo will be saved to the iOS Camera Roll.
-storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this is true.
+storageOptions.waitUntilSaved | OK | OK | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this is true.
 
 ### The Response Object
 


### PR DESCRIPTION
This functionality is present in the iOS part of the library, now it should work on all devices.