### PR TITLE
Fix TypeScript module export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
-
 declare module "react-native-image-picker" {
 
-    export interface Response {
+    interface Response {
         customButton: string;
         didCancel: boolean;
         error: string;
@@ -20,12 +19,12 @@ declare module "react-native-image-picker" {
         timestamp?: string;
     }
 
-    export interface CustomButtonOptions {
+    interface CustomButtonOptions {
         name?: string;
         title?: string;
     }
 
-    export interface Options {
+    interface Options {
         title?: string;
         cancelButtonTitle?: string;
         takePhotoButtonTitle?: string;
@@ -44,7 +43,7 @@ declare module "react-native-image-picker" {
         storageOptions?: StorageOptions;
     }
 
-    export interface StorageOptions {
+    interface StorageOptions {
         skipBackup?: boolean;
         path?: string;
         cameraRoll?: boolean;
@@ -52,11 +51,12 @@ declare module "react-native-image-picker" {
     }
 
 
-    export default class ImagePicker {
+    class ImagePicker {
         static showImagePicker(options: Options, callback: (response: Response) => void): void;
         static launchCamera(options: Options, callback: (response: Response) => void): void;
         static launchImageLibrary(options: Options, callback: (response: Response) => void): void;
     }
 
-}
+    export = ImagePicker;
 
+}


### PR DESCRIPTION
The current TypeScript declaration exports the module as a `default` export. This is incorrect because the module is exported as CommonJS single export and should be consumed with `export = require(...)` TypeScript's construct.

This change addresses the issue by exporting the module with `export =`.