### PR TITLE
Fixed bug of getting authority for Android 5.1

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.imagepicker" >
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  package="com.imagepicker"
+  >
     <application>
-        <provider
+      <provider
+            tools:replace="android:authorities"
             android:name="android.support.v4.content.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"


### PR DESCRIPTION
Problem was described in https://github.com/marcshilling/react-native-image-picker/issues/485.

Thanks @dsvictor94 for help.