### PR TITLE
Undo commit bf79750 to solve the Warning 'authorities was tagged at AndroidManifest.xml:8 to replace other declarations but no other declaration present'

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
   package="com.imagepicker"
   >
     <application>
       <provider
-            tools:replace="android:authorities"
             android:name="android.support.v4.content.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"


### PR DESCRIPTION
In the process to solve the issues #486 the commit [bf79750 - Fixed bug of getting authority for Android 5.1](https://github.com/marcshilling/react-native-image-picker/commit/bf79750) was did, but it not solved the problem and just added the warning to the build process
```
Warning: provider#android.support.v4.content.FileProvider@android:authorities was tagged at AndroidManifest.xml:8 to replace other declarations but no other declaration present
```

This pull request intends to revert this commit