### PR TITLE
Fixed minimal version for FileProvider

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -825,7 +825,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                                                  @NonNull final File file)
   {
     Uri result = null;
-    if (Build.VERSION.SDK_INT < 19)
+    if (Build.VERSION.SDK_INT < 21)
     {
       result = Uri.fromFile(file);
     }


### PR DESCRIPTION
Just updated minimal version API from 19 to 21 for working with FileProvider.

This fix covers crash from #485.