### PR TITLE
Android: fix cancellation handling

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -307,7 +307,7 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
     // user cancel
     if (resultCode != Activity.RESULT_OK) {
-      responseHelper.invokeResponse(callback);
+      responseHelper.invokeCancel(callback);
       callback = null;
       return;
     }


### PR DESCRIPTION
- This was broken by #496.
- Currently, the response object is empty, lacking the `didCancel` flag.