### PR TITLE
Allow saving to camera roll on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ noData | OK | OK | If true, disables the base64 `data` field from being generate
 storageOptions | OK | OK | If this key is provided, the image will be saved in your app's `Documents` directory on iOS, or your app's `Pictures` directory on Android (rather than a temporary directory)
 storageOptions.skipBackup | OK | - | If true, the photo will NOT be backed up to iCloud
 storageOptions.path | OK | - | If set, will save the image at `Documents/[path]/` rather than the root `Documents`
-storageOptions.cameraRoll | OK | - | If true, the cropped photo will be saved to the iOS Camera Roll.
+storageOptions.cameraRoll | OK | OK | If true, the cropped photo will be saved to the iOS Camera Roll or Android DCIM folder.
 storageOptions.waitUntilSaved | OK | - | If true, will delay the response callback until after the photo/video was saved to the Camera Roll. If the photo or video was just taken, then the file name and timestamp fields are only provided in the response object when this is true.
 permissionDenied.title | - | OK | Title of explaining permissions dialog. By default `Permission denied`.
 permissionDenied.text | - | OK | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.


### PR DESCRIPTION
Fixes https://github.com/marcshilling/react-native-image-picker/issues/508.

Note: Either https://github.com/marcshilling/react-native-image-picker/pull/513 or this PR should be merged. We needed this feature right away for our app, so I needed to do the work anyway and figured I'd submit a PR.

Tested and verified on Android emulator and physical device.

@marcshilling please let me know if you'd like anything tweaked. Note that the temp image is never deleted after resizing, but that's an existing bug that isn't changed by this PR.